### PR TITLE
mac m1 mps support

### DIFF
--- a/preprocessor/meshgraphormer.py
+++ b/preprocessor/meshgraphormer.py
@@ -82,6 +82,14 @@ class MeshGraphormerMediapipe(Preprocessor):
         set_seed(args.seed, args.num_gpus)
         #logger.info("Using {} GPUs".format(args.num_gpus))
 
+        if args.device == "cuda" or args.device == "mps":
+            if torch.cuda.is_available():
+                args.device = "cuda"
+            else:
+                args.device = "mps"
+        else:
+            args.device = "cpu"
+
         # Mesh and MANO utils
         mano_model = MANO().to(args.device)
         mano_model.layer = mano_model.layer.cuda()


### PR DESCRIPTION
  File "/Users/doheyonkim/Depot/stable-diffusion-webui/venv/lib/python3.10/site-packages/mesh_graphormer/modeling/_mano.py", line 124, in <listcomp>
    self._U = [u.to(device) for u in self._U]
NotImplementedError: Could not run 'aten::empty.memory_format' with arguments from the 'SparseMPS' backend. This could be because the operator doesn't exist for this backend, or was omitted during the selective/custom build process (if using custom build). If you are a Facebook employee using PyTorch on mobile, please visit https://fburl.com/ptmfixes for possible resolutions. 'aten::empty.memory_format' is only available for these backends: [CPU, MPS, Meta, QuantizedCPU, QuantizedMeta, MkldnnCPU, SparseCPU, SparseMeta, SparseCsrCPU, BackendSelect, Python, FuncTorchDynamicLayerBackMode, Functionalize, Named, Conjugate, Negative, ZeroTensor, ADInplaceOrView, AutogradOther, AutogradCPU, AutogradCUDA, AutogradHIP, AutogradXLA, AutogradMPS, AutogradIPU, AutogradXPU, AutogradHPU, AutogradVE, AutogradLazy, AutogradMTIA, AutogradPrivateUse1, AutogradPrivateUse2, AutogradPrivateUse3, AutogradMeta, AutogradNestedTensor, Tracer, AutocastCPU, AutocastCUDA, FuncTorchBatched, FuncTorchVmapMode, Batched, VmapMode, FuncTorchGradWrapper, PythonTLSSnapshot, FuncTorchDynamicLayerFrontMode, PreDispatch, PythonDispatcher].

CPU: registered at /Users/runner/work/pytorch/pytorch/pytorch/build/aten/src/ATen/RegisterCPU.cpp:31188 [kernel]

Fixed an issue where hand refine did not work on Mac M1 when using it as a plugin in the Stable Diffusion Web UI.